### PR TITLE
Fix sensitive variable leaks

### DIFF
--- a/django/views/debug.py
+++ b/django/views/debug.py
@@ -241,37 +241,39 @@ class SafeExceptionReporterFilter:
         Replace the values of variables marked as sensitive with
         stars (*********).
         """
-        sensitive_variables = None
+        sensitive_variables = set()
 
-        # Coroutines don't have a proper `f_back` so they need to be inspected
-        # separately. Handle this by stashing the registered sensitive
-        # variables in a global dict indexed by `hash(file_path:line_number)`.
-        if (
-            tb_frame.f_code.co_flags & inspect.CO_COROUTINE != 0
-            and tb_frame.f_code.co_name != "sensitive_variables_wrapper"
-        ):
-            key = hash(
-                f"{tb_frame.f_code.co_filename}:{tb_frame.f_code.co_firstlineno}"
-            )
-            sensitive_variables = coroutine_functions_to_sensitive_variables.get(
-                key, None
-            )
+        # Collect sensitive variable names from the current frame and all
+        # calling frames. Coroutines don't have a proper `f_back`, so annotations
+        # for them are stored in a global dict indexed by
+        # ``hash(file_path:line_number)``.
+        current_frame = tb_frame
+        while current_frame is not None:
+            vars_in_frame = None
+            if (
+                current_frame.f_code.co_flags & inspect.CO_COROUTINE != 0
+                and current_frame.f_code.co_name != "sensitive_variables_wrapper"
+            ):
+                key = hash(
+                    f"{current_frame.f_code.co_filename}:{current_frame.f_code.co_firstlineno}"
+                )
+                vars_in_frame = coroutine_functions_to_sensitive_variables.get(key)
 
-        if sensitive_variables is None:
-            # Loop through the frame's callers to see if the
-            # sensitive_variables decorator was used.
-            current_frame = tb_frame
-            while current_frame is not None:
-                if (
-                    current_frame.f_code.co_name == "sensitive_variables_wrapper"
-                    and "sensitive_variables_wrapper" in current_frame.f_locals
-                ):
-                    # The sensitive_variables decorator was used, so take note
-                    # of the sensitive variables' names.
-                    wrapper = current_frame.f_locals["sensitive_variables_wrapper"]
-                    sensitive_variables = getattr(wrapper, "sensitive_variables", None)
+            if (
+                vars_in_frame is None
+                and current_frame.f_code.co_name == "sensitive_variables_wrapper"
+                and "sensitive_variables_wrapper" in current_frame.f_locals
+            ):
+                wrapper = current_frame.f_locals["sensitive_variables_wrapper"]
+                vars_in_frame = getattr(wrapper, "sensitive_variables", None)
+
+            if vars_in_frame:
+                if vars_in_frame == "__ALL__":
+                    sensitive_variables = "__ALL__"
                     break
-                current_frame = current_frame.f_back
+                sensitive_variables.update(vars_in_frame)
+
+            current_frame = current_frame.f_back
 
         cleansed = {}
         if self.is_active(request) and sensitive_variables:

--- a/tests/view_tests/tests/test_debug.py
+++ b/tests/view_tests/tests/test_debug.py
@@ -51,6 +51,7 @@ from ..views import (
     paranoid_view,
     sensitive_args_function_caller,
     sensitive_kwargs_function_caller,
+    sensitive_passthrough_view,
     sensitive_method_view,
     sensitive_view,
 )
@@ -1741,6 +1742,18 @@ class ExceptionReporterFilterTests(
             self.verify_safe_email(
                 sensitive_kwargs_function_caller, check_for_POST_params=False
             )
+
+    def test_sensitive_variable_passthrough(self):
+        """
+        Sensitive variables don't leak when passed through another function.
+        """
+        with self.settings(DEBUG=True):
+            self.verify_unsafe_response(sensitive_passthrough_view, check_for_POST_params=False)
+            self.verify_unsafe_email(sensitive_passthrough_view, check_for_POST_params=False)
+
+        with self.settings(DEBUG=False):
+            self.verify_safe_response(sensitive_passthrough_view, check_for_POST_params=False)
+            self.verify_safe_email(sensitive_passthrough_view, check_for_POST_params=False)
 
     def test_callable_settings(self):
         """

--- a/tests/view_tests/views.py
+++ b/tests/view_tests/views.py
@@ -280,6 +280,25 @@ def sensitive_kwargs_function(sauce=None):
     raise Exception
 
 
+def passthrough_backend(password):
+    raise Exception
+
+
+@sensitive_variables("password")
+def sensitive_passthrough_function(password):
+    passthrough_backend(password)
+
+
+def sensitive_passthrough_view(request):
+    password = request.POST["password"]
+    try:
+        sensitive_passthrough_function(password)
+    except Exception:
+        exc_info = sys.exc_info()
+        send_log(request, exc_info)
+        return technical_500_response(request, *exc_info)
+
+
 class UnsafeExceptionReporterFilter(SafeExceptionReporterFilter):
     """
     Ignores all the filtering done by its parent class.


### PR DESCRIPTION
## Summary
- propagate sensitive variable names across stack frames
- add test coverage for sensitive variable passthrough

## Testing
- `tox -e isort` *(fails: tox not installed)*
- `python -m flake8` *(fails: module not found)*

------
https://chatgpt.com/codex/tasks/task_b_683da02177fc832d8d7455817d2ba030