### PR TITLE
Use assertRaisesMessage in tests

### DIFF
--- a/tests/auth_tests/test_validators.py
+++ b/tests/auth_tests/test_validators.py
@@ -66,16 +66,15 @@ class PasswordValidationTest(SimpleTestCase):
             "This password is too short. It must contain at least 12 characters."
         )
 
-        with self.assertRaises(ValidationError) as cm:
+        with self.assertRaisesMessage(ValidationError, msg_too_short):
             validate_password("django4242")
-        self.assertEqual(cm.exception.messages, [msg_too_short])
         self.assertEqual(cm.exception.error_list[0].code, "password_too_short")
 
-        with self.assertRaises(ValidationError) as cm:
+        with self.assertRaisesMessage(
+            ValidationError, "This password is too common."
+        ) as cm:
             validate_password("password")
-        self.assertEqual(
-            cm.exception.messages, ["This password is too common.", msg_too_short]
-        )
+        self.assertEqual(cm.exception.messages, ["This password is too common.", msg_too_short])
         self.assertEqual(cm.exception.error_list[0].code, "password_too_common")
 
         self.assertIsNone(validate_password("password", password_validators=[]))
@@ -130,16 +129,20 @@ class MinimumLengthValidatorTest(SimpleTestCase):
         self.assertIsNone(MinimumLengthValidator().validate("12345678"))
         self.assertIsNone(MinimumLengthValidator(min_length=3).validate("123"))
 
-        with self.assertRaises(ValidationError) as cm:
+        with self.assertRaisesMessage(
+            ValidationError,
+            expected_error % 8,
+        ) as cm:
             MinimumLengthValidator().validate("1234567")
-        self.assertEqual(cm.exception.messages, [expected_error % 8])
         error = cm.exception.error_list[0]
         self.assertEqual(error.code, "password_too_short")
         self.assertEqual(error.params, {"min_length": 8})
 
-        with self.assertRaises(ValidationError) as cm:
+        with self.assertRaisesMessage(
+            ValidationError,
+            expected_error % 3,
+        ) as cm:
             MinimumLengthValidator(min_length=3).validate("12")
-        self.assertEqual(cm.exception.messages, [expected_error % 3])
         error = cm.exception.error_list[0]
         self.assertEqual(error.code, "password_too_short")
         self.assertEqual(error.params, {"min_length": 3})
@@ -196,29 +199,34 @@ class UserAttributeSimilarityValidatorTest(TestCase):
 
         self.assertIsNone(UserAttributeSimilarityValidator().validate("testclient"))
 
-        with self.assertRaises(ValidationError) as cm:
+        with self.assertRaisesMessage(
+            ValidationError, expected_error % "username"
+        ) as cm:
             UserAttributeSimilarityValidator().validate("testclient", user=user)
         self.assertEqual(cm.exception.messages, [expected_error % "username"])
         self.assertEqual(cm.exception.error_list[0].code, "password_too_similar")
 
-        with self.assertRaises(ValidationError) as cm:
+        with self.assertRaisesMessage(
+            ValidationError, expected_error % "email address"
+        ) as cm:
             UserAttributeSimilarityValidator().validate("example.com", user=user)
-        self.assertEqual(cm.exception.messages, [expected_error % "email address"])
 
-        with self.assertRaises(ValidationError) as cm:
+        with self.assertRaisesMessage(
+            ValidationError, expected_error % "first name"
+        ) as cm:
             UserAttributeSimilarityValidator(
                 user_attributes=["first_name"],
                 max_similarity=0.3,
             ).validate("testclient", user=user)
-        self.assertEqual(cm.exception.messages, [expected_error % "first name"])
         # max_similarity=1 doesn't allow passwords that are identical to the
         # attribute's value.
-        with self.assertRaises(ValidationError) as cm:
+        with self.assertRaisesMessage(
+            ValidationError, expected_error % "first name"
+        ) as cm:
             UserAttributeSimilarityValidator(
                 user_attributes=["first_name"],
                 max_similarity=1,
             ).validate(user.first_name, user=user)
-        self.assertEqual(cm.exception.messages, [expected_error % "first name"])
         # Very low max_similarity is rejected.
         msg = "max_similarity must be at least 0.1"
         with self.assertRaisesMessage(ValueError, msg):
@@ -239,7 +247,9 @@ class UserAttributeSimilarityValidatorTest(TestCase):
             def username(self):
                 return "foobar"
 
-        with self.assertRaises(ValidationError) as cm:
+        with self.assertRaisesMessage(
+            ValidationError, "The password is too similar to the username."
+        ) as cm:
             UserAttributeSimilarityValidator().validate("foobar", user=TestUser())
         self.assertEqual(
             cm.exception.messages, ["The password is too similar to the username."]
@@ -293,7 +303,7 @@ class CommonPasswordValidatorTest(SimpleTestCase):
         expected_error = "This password is too common."
         self.assertIsNone(CommonPasswordValidator().validate("a-safe-password"))
 
-        with self.assertRaises(ValidationError) as cm:
+        with self.assertRaisesMessage(ValidationError, expected_error) as cm:
             CommonPasswordValidator().validate("godzilla")
         self.assertEqual(cm.exception.messages, [expected_error])
 
@@ -302,7 +312,7 @@ class CommonPasswordValidatorTest(SimpleTestCase):
         common_hexed_passwords = ["asdfjkl:", "&#2336:"]
         for password in common_hexed_passwords:
             with self.subTest(password=password):
-                with self.assertRaises(ValidationError) as cm:
+                with self.assertRaisesMessage(ValidationError, expected_error) as cm:
                     CommonPasswordValidator().validate(password)
                 self.assertEqual(cm.exception.messages, [expected_error])
 
@@ -314,7 +324,7 @@ class CommonPasswordValidatorTest(SimpleTestCase):
         expected_error = "This password is too common."
         self.assertIsNone(validator.validate("a-safe-password"))
 
-        with self.assertRaises(ValidationError) as cm:
+        with self.assertRaisesMessage(ValidationError, expected_error) as cm:
             validator.validate("from-my-custom-list")
         self.assertEqual(cm.exception.messages, [expected_error])
         self.assertEqual(cm.exception.error_list[0].code, "password_too_common")
@@ -346,7 +356,7 @@ class NumericPasswordValidatorTest(SimpleTestCase):
         expected_error = "This password is entirely numeric."
         self.assertIsNone(NumericPasswordValidator().validate("a-safe-password"))
 
-        with self.assertRaises(ValidationError) as cm:
+        with self.assertRaisesMessage(ValidationError, expected_error) as cm:
             NumericPasswordValidator().validate("42424242")
         self.assertEqual(cm.exception.messages, [expected_error])
         self.assertEqual(cm.exception.error_list[0].code, "password_entirely_numeric")

--- a/tests/composite_pk/test_models.py
+++ b/tests/composite_pk/test_models.py
@@ -141,9 +141,10 @@ class CompositePKModelsTests(TestCase):
         user = User.objects.get(pk=self.user_1.pk)
         user.id = None
 
-        with self.assertRaises(ValidationError) as ctx:
+        with self.assertRaisesMessage(
+            ValidationError, "User with this Email already exists."
+        ) as ctx:
             user.validate_unique()
-
         self.assertSequenceEqual(
             ctx.exception.messages, ("User with this Email already exists.",)
         )

--- a/tests/postgres_tests/test_array.py
+++ b/tests/postgres_tests/test_array.py
@@ -1049,7 +1049,10 @@ class TestStringSerialization(PostgreSQLSimpleTestCase):
 class TestValidation(PostgreSQLSimpleTestCase):
     def test_unbounded(self):
         field = ArrayField(models.IntegerField())
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with self.assertRaisesMessage(
+            exceptions.ValidationError,
+            "Item 2 in the array did not validate: This field cannot be null.",
+        ) as cm:
             field.clean([1, None], None)
         self.assertEqual(cm.exception.code, "item_invalid")
         self.assertEqual(
@@ -1065,7 +1068,10 @@ class TestValidation(PostgreSQLSimpleTestCase):
     def test_with_size(self):
         field = ArrayField(models.IntegerField(), size=3)
         field.clean([1, 2, 3], None)
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with self.assertRaisesMessage(
+            exceptions.ValidationError,
+            "List contains 4 items, it should contain no more than 3.",
+        ) as cm:
             field.clean([1, 2, 3, 4], None)
         self.assertEqual(
             cm.exception.messages[0],
@@ -1082,7 +1088,9 @@ class TestValidation(PostgreSQLSimpleTestCase):
     def test_nested_array_mismatch(self):
         field = ArrayField(ArrayField(models.IntegerField()))
         field.clean([[1, 2], [3, 4]], None)
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with self.assertRaisesMessage(
+            exceptions.ValidationError, "Nested arrays must have the same length."
+        ) as cm:
             field.clean([[1, 2], [3, 4, 5]], None)
         self.assertEqual(cm.exception.code, "nested_array_mismatch")
         self.assertEqual(
@@ -1091,7 +1099,10 @@ class TestValidation(PostgreSQLSimpleTestCase):
 
     def test_with_base_field_error_params(self):
         field = ArrayField(models.CharField(max_length=2))
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with self.assertRaisesMessage(
+            exceptions.ValidationError,
+            "Item 1 in the array did not validate: Ensure this value has at most 2 characters (it has 3).",
+        ) as cm:
             field.clean(["abc"], None)
         self.assertEqual(len(cm.exception.error_list), 1)
         exception = cm.exception.error_list[0]
@@ -1111,7 +1122,10 @@ class TestValidation(PostgreSQLSimpleTestCase):
             models.IntegerField(validators=[validators.MinValueValidator(1)])
         )
         field.clean([1, 2], None)
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with self.assertRaisesMessage(
+            exceptions.ValidationError,
+            "Item 1 in the array did not validate: Ensure this value is greater than or equal to 1.",
+        ) as cm:
             field.clean([0], None)
         self.assertEqual(len(cm.exception.error_list), 1)
         exception = cm.exception.error_list[0]
@@ -1134,7 +1148,10 @@ class TestSimpleFormField(PostgreSQLSimpleTestCase):
 
     def test_to_python_fail(self):
         field = SimpleArrayField(forms.IntegerField())
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with self.assertRaisesMessage(
+            exceptions.ValidationError,
+            "Item 1 in the array did not validate: Enter a whole number.",
+        ) as cm:
             field.clean("a,b,9")
         self.assertEqual(
             cm.exception.messages[0],
@@ -1143,7 +1160,10 @@ class TestSimpleFormField(PostgreSQLSimpleTestCase):
 
     def test_validate_fail(self):
         field = SimpleArrayField(forms.CharField(required=True))
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with self.assertRaisesMessage(
+            exceptions.ValidationError,
+            "Item 3 in the array did not validate: This field is required.",
+        ) as cm:
             field.clean("a,b,")
         self.assertEqual(
             cm.exception.messages[0],
@@ -1181,7 +1201,10 @@ class TestSimpleFormField(PostgreSQLSimpleTestCase):
 
     def test_validators_fail(self):
         field = SimpleArrayField(forms.RegexField("[a-e]{2}"))
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with self.assertRaisesMessage(
+            exceptions.ValidationError,
+            "Item 1 in the array did not validate: Enter a valid value.",
+        ) as cm:
             field.clean("a,bc,de")
         self.assertEqual(
             cm.exception.messages[0],
@@ -1205,7 +1228,10 @@ class TestSimpleFormField(PostgreSQLSimpleTestCase):
 
     def test_max_length(self):
         field = SimpleArrayField(forms.CharField(), max_length=2)
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with self.assertRaisesMessage(
+            exceptions.ValidationError,
+            "List contains 3 items, it should contain no more than 2.",
+        ) as cm:
             field.clean("a,b,c")
         self.assertEqual(
             cm.exception.messages[0],
@@ -1214,7 +1240,10 @@ class TestSimpleFormField(PostgreSQLSimpleTestCase):
 
     def test_min_length(self):
         field = SimpleArrayField(forms.CharField(), min_length=4)
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with self.assertRaisesMessage(
+            exceptions.ValidationError,
+            "List contains 3 items, it should contain no fewer than 4.",
+        ) as cm:
             field.clean("a,b,c")
         self.assertEqual(
             cm.exception.messages[0],
@@ -1230,7 +1259,9 @@ class TestSimpleFormField(PostgreSQLSimpleTestCase):
 
     def test_required(self):
         field = SimpleArrayField(forms.CharField(), required=True)
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with self.assertRaisesMessage(
+            exceptions.ValidationError, "This field is required."
+        ) as cm:
             field.clean("")
         self.assertEqual(cm.exception.messages[0], "This field is required.")
 

--- a/tests/postgres_tests/test_hstore.py
+++ b/tests/postgres_tests/test_hstore.py
@@ -349,7 +349,9 @@ class TestSerialization(PostgreSQLSimpleTestCase):
 class TestValidation(PostgreSQLSimpleTestCase):
     def test_not_a_string(self):
         field = HStoreField()
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with self.assertRaisesMessage(
+            exceptions.ValidationError, "The value of “a” is not a string or null."
+        ) as cm:
             field.clean({"a": 1}, None)
         self.assertEqual(cm.exception.code, "not_a_string")
         self.assertEqual(
@@ -370,7 +372,9 @@ class TestFormField(PostgreSQLSimpleTestCase):
 
     def test_invalid_json(self):
         field = forms.HStoreField()
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with self.assertRaisesMessage(
+            exceptions.ValidationError, "Could not load JSON data."
+        ) as cm:
             field.clean('{"a": "b"')
         self.assertEqual(cm.exception.messages[0], "Could not load JSON data.")
         self.assertEqual(cm.exception.code, "invalid_json")
@@ -439,7 +443,9 @@ class TestValidator(PostgreSQLSimpleTestCase):
 
     def test_missing_keys(self):
         validator = KeysValidator(keys=["a", "b"])
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with self.assertRaisesMessage(
+            exceptions.ValidationError, "Some keys were missing: b"
+        ) as cm:
             validator({"a": "foo", "c": "baz"})
         self.assertEqual(cm.exception.messages[0], "Some keys were missing: b")
         self.assertEqual(cm.exception.code, "missing_keys")
@@ -450,7 +456,9 @@ class TestValidator(PostgreSQLSimpleTestCase):
 
     def test_extra_keys(self):
         validator = KeysValidator(keys=["a", "b"], strict=True)
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with self.assertRaisesMessage(
+            exceptions.ValidationError, "Some unknown keys were provided: c"
+        ) as cm:
             validator({"a": "foo", "b": "bar", "c": "baz"})
         self.assertEqual(cm.exception.messages[0], "Some unknown keys were provided: c")
         self.assertEqual(cm.exception.code, "extra_keys")
@@ -460,11 +468,13 @@ class TestValidator(PostgreSQLSimpleTestCase):
             "missing_keys": "Foobar",
         }
         validator = KeysValidator(keys=["a", "b"], strict=True, messages=messages)
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with self.assertRaisesMessage(exceptions.ValidationError, "Foobar") as cm:
             validator({"a": "foo", "c": "baz"})
         self.assertEqual(cm.exception.messages[0], "Foobar")
         self.assertEqual(cm.exception.code, "missing_keys")
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with self.assertRaisesMessage(
+            exceptions.ValidationError, "Some unknown keys were provided: c"
+        ) as cm:
             validator({"a": "foo", "b": "bar", "c": "baz"})
         self.assertEqual(cm.exception.messages[0], "Some unknown keys were provided: c")
         self.assertEqual(cm.exception.code, "extra_keys")

--- a/tests/postgres_tests/test_ranges.py
+++ b/tests/postgres_tests/test_ranges.py
@@ -635,7 +635,7 @@ class TestValidators(PostgreSQLSimpleTestCase):
         validator = RangeMaxValueValidator(5)
         validator(NumericRange(0, 5))
         msg = "Ensure that the upper bound of the range is not greater than 5."
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with self.assertRaisesMessage(exceptions.ValidationError, msg) as cm:
             validator(NumericRange(0, 10))
         self.assertEqual(cm.exception.messages[0], msg)
         self.assertEqual(cm.exception.code, "max_value")
@@ -646,7 +646,7 @@ class TestValidators(PostgreSQLSimpleTestCase):
         validator = RangeMinValueValidator(5)
         validator(NumericRange(10, 15))
         msg = "Ensure that the lower bound of the range is not less than 5."
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with self.assertRaisesMessage(exceptions.ValidationError, msg) as cm:
             validator(NumericRange(0, 10))
         self.assertEqual(cm.exception.messages[0], msg)
         self.assertEqual(cm.exception.code, "min_value")
@@ -801,7 +801,10 @@ class TestFormField(PostgreSQLSimpleTestCase):
 
     def test_integer_lower_bound_higher(self):
         field = pg_forms.IntegerRangeField()
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with self.assertRaisesMessage(
+            exceptions.ValidationError,
+            "The start of the range must not exceed the end of the range.",
+        ) as cm:
             field.clean(["10", "2"])
         self.assertEqual(
             cm.exception.messages[0],
@@ -816,26 +819,32 @@ class TestFormField(PostgreSQLSimpleTestCase):
 
     def test_integer_incorrect_data_type(self):
         field = pg_forms.IntegerRangeField()
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with self.assertRaisesMessage(
+            exceptions.ValidationError, "Enter two whole numbers."
+        ) as cm:
             field.clean("1")
         self.assertEqual(cm.exception.messages[0], "Enter two whole numbers.")
         self.assertEqual(cm.exception.code, "invalid")
 
     def test_integer_invalid_lower(self):
         field = pg_forms.IntegerRangeField()
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with self.assertRaisesMessage(
+            exceptions.ValidationError, "Enter a whole number."
+        ) as cm:
             field.clean(["a", "2"])
-        self.assertEqual(cm.exception.messages[0], "Enter a whole number.")
 
     def test_integer_invalid_upper(self):
         field = pg_forms.IntegerRangeField()
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with self.assertRaisesMessage(
+            exceptions.ValidationError, "Enter a whole number."
+        ) as cm:
             field.clean(["1", "b"])
-        self.assertEqual(cm.exception.messages[0], "Enter a whole number.")
 
     def test_integer_required(self):
         field = pg_forms.IntegerRangeField(required=True)
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with self.assertRaisesMessage(
+            exceptions.ValidationError, "This field is required."
+        ) as cm:
             field.clean(["", ""])
         self.assertEqual(cm.exception.messages[0], "This field is required.")
         value = field.clean([1, ""])
@@ -843,7 +852,10 @@ class TestFormField(PostgreSQLSimpleTestCase):
 
     def test_decimal_lower_bound_higher(self):
         field = pg_forms.DecimalRangeField()
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with self.assertRaisesMessage(
+            exceptions.ValidationError,
+            "The start of the range must not exceed the end of the range.",
+        ) as cm:
             field.clean(["1.8", "1.6"])
         self.assertEqual(
             cm.exception.messages[0],
@@ -858,26 +870,32 @@ class TestFormField(PostgreSQLSimpleTestCase):
 
     def test_decimal_incorrect_data_type(self):
         field = pg_forms.DecimalRangeField()
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with self.assertRaisesMessage(
+            exceptions.ValidationError, "Enter two numbers."
+        ) as cm:
             field.clean("1.6")
         self.assertEqual(cm.exception.messages[0], "Enter two numbers.")
         self.assertEqual(cm.exception.code, "invalid")
 
     def test_decimal_invalid_lower(self):
         field = pg_forms.DecimalRangeField()
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with self.assertRaisesMessage(
+            exceptions.ValidationError, "Enter a number."
+        ) as cm:
             field.clean(["a", "3.1415926"])
-        self.assertEqual(cm.exception.messages[0], "Enter a number.")
 
     def test_decimal_invalid_upper(self):
         field = pg_forms.DecimalRangeField()
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with self.assertRaisesMessage(
+            exceptions.ValidationError, "Enter a number."
+        ) as cm:
             field.clean(["1.61803399", "b"])
-        self.assertEqual(cm.exception.messages[0], "Enter a number.")
 
     def test_decimal_required(self):
         field = pg_forms.DecimalRangeField(required=True)
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with self.assertRaisesMessage(
+            exceptions.ValidationError, "This field is required."
+        ) as cm:
             field.clean(["", ""])
         self.assertEqual(cm.exception.messages[0], "This field is required.")
         value = field.clean(["1.61803399", ""])
@@ -885,7 +903,10 @@ class TestFormField(PostgreSQLSimpleTestCase):
 
     def test_date_lower_bound_higher(self):
         field = pg_forms.DateRangeField()
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with self.assertRaisesMessage(
+            exceptions.ValidationError,
+            "The start of the range must not exceed the end of the range.",
+        ) as cm:
             field.clean(["2013-04-09", "1976-04-16"])
         self.assertEqual(
             cm.exception.messages[0],
@@ -900,26 +921,28 @@ class TestFormField(PostgreSQLSimpleTestCase):
 
     def test_date_incorrect_data_type(self):
         field = pg_forms.DateRangeField()
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with self.assertRaisesMessage(
+            exceptions.ValidationError, "Enter two valid dates."
+        ) as cm:
             field.clean("1")
         self.assertEqual(cm.exception.messages[0], "Enter two valid dates.")
         self.assertEqual(cm.exception.code, "invalid")
 
     def test_date_invalid_lower(self):
         field = pg_forms.DateRangeField()
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with self.assertRaisesMessage(exceptions.ValidationError, "Enter a valid date.") as cm:
             field.clean(["a", "2013-04-09"])
-        self.assertEqual(cm.exception.messages[0], "Enter a valid date.")
 
     def test_date_invalid_upper(self):
         field = pg_forms.DateRangeField()
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with self.assertRaisesMessage(exceptions.ValidationError, "Enter a valid date.") as cm:
             field.clean(["2013-04-09", "b"])
-        self.assertEqual(cm.exception.messages[0], "Enter a valid date.")
 
     def test_date_required(self):
         field = pg_forms.DateRangeField(required=True)
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with self.assertRaisesMessage(
+            exceptions.ValidationError, "This field is required."
+        ) as cm:
             field.clean(["", ""])
         self.assertEqual(cm.exception.messages[0], "This field is required.")
         value = field.clean(["1976-04-16", ""])
@@ -943,7 +966,10 @@ class TestFormField(PostgreSQLSimpleTestCase):
 
     def test_datetime_lower_bound_higher(self):
         field = pg_forms.DateTimeRangeField()
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with self.assertRaisesMessage(
+            exceptions.ValidationError,
+            "The start of the range must not exceed the end of the range.",
+        ) as cm:
             field.clean(["2006-10-25 14:59", "2006-10-25 14:58"])
         self.assertEqual(
             cm.exception.messages[0],
@@ -960,26 +986,32 @@ class TestFormField(PostgreSQLSimpleTestCase):
 
     def test_datetime_incorrect_data_type(self):
         field = pg_forms.DateTimeRangeField()
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with self.assertRaisesMessage(
+            exceptions.ValidationError, "Enter two valid date/times."
+        ) as cm:
             field.clean("2013-04-09 11:45")
         self.assertEqual(cm.exception.messages[0], "Enter two valid date/times.")
         self.assertEqual(cm.exception.code, "invalid")
 
     def test_datetime_invalid_lower(self):
         field = pg_forms.DateTimeRangeField()
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with self.assertRaisesMessage(
+            exceptions.ValidationError, "Enter a valid date/time."
+        ) as cm:
             field.clean(["45", "2013-04-09 11:45"])
-        self.assertEqual(cm.exception.messages[0], "Enter a valid date/time.")
 
     def test_datetime_invalid_upper(self):
         field = pg_forms.DateTimeRangeField()
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with self.assertRaisesMessage(
+            exceptions.ValidationError, "Enter a valid date/time."
+        ) as cm:
             field.clean(["2013-04-09 11:45", "sweet pickles"])
-        self.assertEqual(cm.exception.messages[0], "Enter a valid date/time.")
 
     def test_datetime_required(self):
         field = pg_forms.DateTimeRangeField(required=True)
-        with self.assertRaises(exceptions.ValidationError) as cm:
+        with self.assertRaisesMessage(
+            exceptions.ValidationError, "This field is required."
+        ) as cm:
             field.clean(["", ""])
         self.assertEqual(cm.exception.messages[0], "This field is required.")
         value = field.clean(["2013-04-09 11:45", ""])

--- a/tests/validation/test_error_messages.py
+++ b/tests/validation/test_error_messages.py
@@ -6,7 +6,7 @@ from django.db import models
 
 class ValidationMessagesTest(TestCase):
     def _test_validation_messages(self, field, value, expected):
-        with self.assertRaises(ValidationError) as cm:
+        with self.assertRaisesMessage(ValidationError, expected[0]) as cm:
             field.clean(value, None)
         self.assertEqual(cm.exception.messages, expected)
 


### PR DESCRIPTION
## Summary
- prefer `assertRaisesMessage()` over checking `cm.exception.messages`

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683da1bb4654832daaad34252dbd9a02